### PR TITLE
7.72 Fix conjuring spell names and some rune effects.

### DIFF
--- a/data/spells/scripts/runes/envenom_rune.lua
+++ b/data/spells/scripts/runes/envenom_rune.lua
@@ -1,7 +1,7 @@
 local combat = Combat()
 combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_EARTHDAMAGE)
-combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_CARNIPHILA)
-combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_EARTH)
+combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_HITBYPOISON)
+combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_POISON)
 
 function onCastSpell(creature, variant)
 	local min = (creature:getLevel() / 80) + (creature:getMagicLevel() * 0.55) + 6

--- a/data/spells/scripts/runes/fireball_rune.lua
+++ b/data/spells/scripts/runes/fireball_rune.lua
@@ -1,6 +1,6 @@
 local combat = Combat()
 combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_FIREDAMAGE)
-combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_FIREATTACK)
+combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_FIREAREA)
 combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_FIRE)
 
 local area = createCombatArea(AREA_CIRCLE2X2)

--- a/data/spells/scripts/runes/sudden_death_rune.lua
+++ b/data/spells/scripts/runes/sudden_death_rune.lua
@@ -1,6 +1,7 @@
 local combat = Combat()
 combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_PHYSICALDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_MORTAREA)
+combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_DEATH)
 combat:setParameter(COMBAT_PARAM_BLOCKARMOR, 1)
 
 function onGetFormulaValues(player, level, magicLevel)

--- a/data/spells/spells.xml
+++ b/data/spells/spells.xml
@@ -281,11 +281,11 @@
 		<vocation name="Sorcerer" />
 		<vocation name="Master Sorcerer" />
 	</instant>
-	<instant group="support" name="Great Fireball Rune" words="adori mas flam" level="30" mana="530" soul="3" aggressive="0" cooldown="2000" needlearn="0" script="conjuring/great_fireball_rune.lua">
+	<instant group="support" name="Great Fireball Rune" words="adori gran flam" level="30" mana="530" soul="3" aggressive="0" cooldown="2000" needlearn="0" script="conjuring/great_fireball_rune.lua">
 		<vocation name="Sorcerer" />
 		<vocation name="Master Sorcerer" />
 	</instant>
-	<instant group="support" name="Heavy Magic Missile Rune" words="adori vis" level="25" mana="350" soul="2" aggressive="0" cooldown="2000" needlearn="0" script="conjuring/heavy_magic_missile_rune.lua">
+	<instant group="support" name="Heavy Magic Missile Rune" words="adori gran" level="25" mana="350" soul="2" aggressive="0" cooldown="2000" needlearn="0" script="conjuring/heavy_magic_missile_rune.lua">
 		<vocation name="Sorcerer" />
 		<vocation name="Master Sorcerer" />
 		<vocation name="Druid" />
@@ -295,7 +295,7 @@
 		<vocation name="Druid" />
 		<vocation name="Elder Druid" />
 	</instant>
-	<instant group="support" name="Light Magic Missile Rune" words="adori min vis" level="15" mana="120" soul="1" aggressive="0" cooldown="2000" needlearn="0" script="conjuring/light_magic_missile_rune.lua">
+	<instant group="support" name="Light Magic Missile Rune" words="adori" level="15" mana="120" soul="1" aggressive="0" cooldown="2000" needlearn="0" script="conjuring/light_magic_missile_rune.lua">
 		<vocation name="Sorcerer" />
 		<vocation name="Druid" />
 		<vocation name="Master Sorcerer" />
@@ -331,7 +331,7 @@
 		<vocation name="Master Sorcerer" />
 		<vocation name="Elder Druid" />
 	</instant>
-	<instant group="support" name="Stalagmite Rune" words="adori tera" level="24" mana="350" soul="2" premium="0" aggressive="0" cooldown="2000" needlearn="0" script="conjuring/stalagmite_rune.lua">
+	<instant group="support" name="Stalagmite Rune" words="adevo res pox" level="24" mana="350" soul="2" premium="0" aggressive="0" cooldown="2000" needlearn="0" script="conjuring/stalagmite_rune.lua">
 		<vocation name="Sorcerer" />
 		<vocation name="Master Sorcerer" />
 		<vocation name="Druid" />


### PR DESCRIPTION
items.xml appears to be updated with the correct rune incantation, but spells.xml was not updated according to previous items.xml changes. 

Some effects like earth should be poison, SD runes didnt have a distance effect, and fireball rune had wrong effect. 

This is probably why there was confusion around a previous (closed) issue about runes not working properly. 