### PR TITLE
7.72: Correct field itemids according to const.h standard

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -1870,88 +1870,93 @@
 	<item id="1484" article="a" name="coal basin" editorsuffix=" (Unmoveable)"/>
 	<item id="1485" article="an" name="empty coal basin" editorsuffix=" (Unmoveable)"/>
 	<item id="1486" article="a" name="stone coal basin"/>
-	<item id="1487" article="a" name="fire field" editorsuffix=" (Not decaying)">
-		<attribute key="type" value="magicfield"/>
+	<item id="1487" article="a" name="fire field">
+		<attribute key="type" value="magicfield" />
+		<attribute key="decayTo" value="1488" />
+		<attribute key="duration" value="120" />
 		<attribute key="field" value="fire">
-			<attribute key="damage" value="20"/>
-			<attribute key="ticks" value="10000"/>
-			<attribute key="count" value="7"/>
-			<attribute key="damage" value="10"/>
+			<attribute key="damage" value="20" />
+			<attribute key="ticks" value="10000" />
+			<attribute key="count" value="7" />
+			<attribute key="damage" value="10" />
 		</attribute>
 	</item>
-	<item id="1488" article="a" name="fire field" editorsuffix=" (Not decaying)">
-		<attribute key="type" value="magicfield"/>
+	<item id="1488" article="a" name="fire field">
+		<attribute key="type" value="magicfield" />
+		<attribute key="decayTo" value="1489" />
+		<attribute key="duration" value="120" />
 		<attribute key="field" value="fire">
-			<attribute key="ticks" value="10000"/>
-			<attribute key="count" value="7"/>
-			<attribute key="damage" value="10"/>
+			<attribute key="ticks" value="10000" />
+			<attribute key="count" value="7" />
+			<attribute key="damage" value="10" />
 		</attribute>
 	</item>
-	<item id="1489" article="a" name="fire field" editorsuffix=" (Not decaying)">
-		<attribute key="type" value="magicfield"/>
-		<attribute key="field" value="fire"/>
+	<item id="1489" article="a" name="fire field">
+		<attribute key="type" value="magicfield" />
+		<attribute key="decayTo" value="0" />
+		<attribute key="duration" value="120" />
+		<attribute key="field" value="fire" />
 	</item>
-	<item id="1490" article="a" name="poison field" editorsuffix=" (Not decaying)">
-		<attribute key="type" value="magicfield"/>
+	<item id="1490" article="a" name="poison field">
+		<attribute key="type" value="magicfield" />
+		<attribute key="decayTo" value="0" />
+		<attribute key="duration" value="120" />
 		<attribute key="field" value="poison">
-			<attribute key="ticks" value="5000"/>
-			<attribute key="start" value="5"/>
-			<attribute key="damage" value="100"/>
+			<attribute key="ticks" value="5000" />
+			<attribute key="start" value="5" />
+			<attribute key="damage" value="100" />
 		</attribute>
 	</item>
-	<item id="1491" article="an" name="energy field" editorsuffix=" (Not decaying)">
-		<attribute key="type" value="magicfield"/>
+	<item id="1491" article="an" name="energy field">
+		<attribute key="type" value="magicfield" />
+		<attribute key="decayTo" value="0" />
+		<attribute key="duration" value="120" />
 		<attribute key="field" value="energy">
-			<attribute key="damage" value="30"/>
-			<attribute key="ticks" value="10000"/>
-			<attribute key="damage" value="25"/>
+			<attribute key="damage" value="30" />
+			<attribute key="ticks" value="10000" />
+			<attribute key="damage" value="25" />
 		</attribute>
 	</item>
-	<item id="1492" article="a" name="fire field">
-		<attribute key="type" value="magicfield"/>
-		<attribute key="decayTo" value="1493"/>
-		<attribute key="duration" value="120"/>
+	<item id="1492" article="a" name="fire field" editorsuffix=" (Not decaying)">
+		<attribute key="type" value="magicfield" />
+		<attribute key="replaceable" value="0" />
 		<attribute key="field" value="fire">
-			<attribute key="damage" value="20"/>
-			<attribute key="ticks" value="10000"/>
-			<attribute key="count" value="7"/>
-			<attribute key="damage" value="10"/>
+			<attribute key="damage" value="20" />
+			<attribute key="ticks" value="10000" />
+			<attribute key="count" value="7" />
+			<attribute key="damage" value="10" />
 		</attribute>
 	</item>
-	<item id="1493" article="a" name="fire field">
-		<attribute key="type" value="magicfield"/>
-		<attribute key="decayTo" value="1494"/>
-		<attribute key="duration" value="120"/>
+	<item id="1493" article="a" name="fire field" editorsuffix=" (Not decaying)">
+		<attribute key="type" value="magicfield" />
+		<attribute key="replaceable" value="0" />
 		<attribute key="field" value="fire">
-			<attribute key="ticks" value="10000"/>
-			<attribute key="count" value="7"/>
-			<attribute key="damage" value="10"/>
+			<attribute key="ticks" value="10000" />
+			<attribute key="count" value="7" />
+			<attribute key="damage" value="10" />
 		</attribute>
 	</item>
-	<item id="1494" article="a" name="fire field">
-		<attribute key="type" value="magicfield"/>
-		<attribute key="decayTo" value="0"/>
-		<attribute key="duration" value="120"/>
-		<attribute key="field" value="fire"/>
+	<item id="1494" article="a" name="fire field" editorsuffix=" (Not decaying)">
+		<attribute key="type" value="magicfield" />
+		<attribute key="replaceable" value="0" />
+		<attribute key="field" value="fire" />
 	</item>
-	<item id="1495" article="an" name="energy field">
-		<attribute key="type" value="magicfield"/>
-		<attribute key="decayTo" value="0"/>
-		<attribute key="duration" value="120"/>
+	<item id="1495" article="an" name="energy field" editorsuffix=" (Not decaying)">
+		<attribute key="type" value="magicfield" />
+		<attribute key="replaceable" value="0" />
 		<attribute key="field" value="energy">
-			<attribute key="damage" value="30"/>
-			<attribute key="ticks" value="10000"/>
-			<attribute key="damage" value="25"/>
+			<attribute key="damage" value="30" />
+			<attribute key="ticks" value="10000" />
+			<attribute key="damage" value="25" />
 		</attribute>
 	</item>
-	<item id="1496" article="a" name="poison field">
-		<attribute key="type" value="magicfield"/>
-		<attribute key="decayTo" value="0"/>
-		<attribute key="duration" value="120"/>
+	<item id="1496" article="a" name="poison field" editorsuffix=" (Not decaying)">
+		<attribute key="type" value="magicfield" />
+		<attribute key="replaceable" value="0" />
 		<attribute key="field" value="poison">
-			<attribute key="ticks" value="5000"/>
-			<attribute key="start" value="5"/>
-			<attribute key="damage" value="100"/>
+			<attribute key="ticks" value="5000" />
+			<attribute key="start" value="5" />
+			<attribute key="damage" value="100" />
 		</attribute>
 	</item>
 	<item id="1497" article="a" name="magic wall">


### PR DESCRIPTION
Fix #31 

The itemids for the constants are defined in const.h, and is a standard across multiple distros. Not sure why it somehow got changed up in items.xml during the protocol downgrade. 