### PR TITLE
Fix on function doCombat

### DIFF
--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -733,8 +733,8 @@ void Combat::doCombat(Creature* caster, const Position& position) const
 					}
 					
 					if (params.targetCallback) {
-						params.targetCallback->onTargetCombat(caster, target);
-					}	
+						params.targetCallback->onTargetCombat(caster, creature);
+					}
 				}
 			}
 		}

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -731,6 +731,10 @@ void Combat::doCombat(Creature* caster, const Position& position) const
 					} else {
 						creature->removeCombatCondition(params.dispelType);
 					}
+					
+					if (params.targetCallback) {
+						params.targetCallback->onTargetCombat(caster, target);
+					}	
 				}
 			}
 		}


### PR DESCRIPTION
Fix on function doCombat to call targetCallback if combat is COMBAT_NONE.

This pull request fixed the Exeta Res bug