### PR TITLE
fix: otcr g_game.enableFeature(GameSequencedPackets)

### DIFF
--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -382,10 +382,7 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 		writeToOutputBuffer(opcodeMessage);
 	}
 
-	// Change packet verifying mode for QT clients
-	if (version >= 1111 && operatingSystem >= CLIENTOS_QT_LINUX && operatingSystem < CLIENTOS_OTCLIENT_LINUX) {
-		setChecksumMode(CHECKSUM_SEQUENCE);
-	}
+	setChecksumMode(CHECKSUM_SEQUENCE);
 
 	// Web login skips the character list request so we need to check the client version again
 	if (version < CLIENT_VERSION_MIN || version > CLIENT_VERSION_MAX) {


### PR DESCRIPTION
@nekiro 

The client is fine, **the issue is with TFS** ,specifically in this line (in void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)[**forgottenserver/src/protocolgame.cpp**]. This if statement only integrates CipSoft, not OTCR Windows.

![image](https://github.com/user-attachments/assets/1fcabbaf-deb4-43ed-b95d-ddceda75e82c)

https://github.com/nekiro/forgottenserver/blob/7573e415e2431a48f7b47b9c7277c98e5e1c389d/src/protocolgame.cpp#L386-L388

